### PR TITLE
Update events.json to add THE CONF

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -12874,5 +12874,21 @@
     "codeOfConduct": "",
     "latitude": 55.604981,
     "longitude": 13.003822
+  },
+  {
+    "name": "THE CONF",
+    "topic": "programming",
+    "url": "http://www.theconf.club",
+    "twitter": "https://twitter.com/theconfbr",
+    "city": "São Paulo",
+    "stateProvince": "São Paulo",
+    "country": "Brazil",
+    "eventStartDate": "2017-09-29T03:00:00.000Z",
+    "eventEndDate": "2017-09-30T03:00:00.000Z",
+    "cfpStartDate": "2017-04-04T03:00:00.000Z",
+    "cfpEndDate": "2017-05-31T03:00:00.000Z",
+    "codeOfConduct": "http://www.theconf.club/pages/code_of_conduct",
+    "latitude": -23.557861,
+    "longitude": -46.668091
   }
 ]


### PR DESCRIPTION
The goal of [TheConf](http://www.theconf.club) is to implement a truly "international" programming-focused conference in Brazil. Meant to introduce Brazilian programmers to the world - and hopefully Latin America in general next time.