### PR TITLE
Added lat/lng for JSConf Iceland

### DIFF
--- a/src/events/2018/2018-March-Iceland-Reykjavik-JSConf Iceland.json
+++ b/src/events/2018/2018-March-Iceland-Reykjavik-JSConf Iceland.json
@@ -1,7 +1,7 @@
 {
   "name": "JSConf Iceland 2018",
   "topic": "Anything remotely related to JavaScript and the community around it",
-  "url": "https://cfp.jsconf.is",
+  "url": "https://2018.jsconf.is",
   "twitter": "jsconfis",
   "city": "Reykjavik",
   "stateProvince": "",
@@ -12,5 +12,6 @@
   "cfpEndDate": "2017-10-31T23:59:59.000Z",
   "latitude": 64.1499049,
   "longitude": -21.9336015,
-  "codeOfConduct": ""
+  "codeOfConduct": "",
+  "cfpUrl": "https://cfp.jsconf.is"
 }

--- a/src/events/2018/2018-March-Iceland-Reykjavik-JSConf Iceland.json
+++ b/src/events/2018/2018-March-Iceland-Reykjavik-JSConf Iceland.json
@@ -10,5 +10,7 @@
   "eventEndDate": "2018-03-02T00:00:00.000Z",
   "cfpStartDate": "2017-10-05T00:00:00.000Z",
   "cfpEndDate": "2017-10-31T23:59:59.000Z",
+  "latitude": 64.1499049,
+  "longitude": -21.9336015,
   "codeOfConduct": ""
 }


### PR DESCRIPTION
A small update to #63 that adds latitude / longitude information to the JSConf Iceland 2018 record.